### PR TITLE
Javers as additional option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ The Audit log page is optional and can be added by choosing the option while run
 
 jhipster-entity-audit module will register itself as a hook for Jhipster and the question to enable audit will available during future entity generation as well
 
+### [BETA] Javers integration
+
+When using mongodb you can use [Javers](http://javers.org/) for entity auditing.
+
+> **BETA Notice** Javers integration is still in beta state. Expect some rough edges!
+
+The module will add [spring-boot integration for javers](http://javers.org/documentation/spring-boot-integration/). Each repository is annotated with the required ``@JaversSpringDataAuditable`` annotation. The new class ``JaversAuthorProvider`` provides javers with the correct user modifying an entity.
+
 ### Installation
 
 As this is a [JHipster](http://jhipster.github.io/) module, we expect you have [JHipster and its related tools already installed](http://jhipster.github.io/installation.html).

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -185,10 +185,15 @@ module.exports = yeoman.generators.Base.extend({
 
       } else {
 
+        var files = [
+          { from: this.javaTemplateDir + '/config/audit/_JaversAuthorProvider.java', to: this.javaDir + 'config/audit/JaversAuthorProvider.java'}
+        ];
+
+        this.copyFiles(files);
         //add required third party dependencies
         if (this.buildTool === 'maven') {
 
-          if (this.databaseType === 'sql') {
+          if (this.databaseType === 'mongodb') {
              jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.1', '<scope>compile</scope>');
              jhipsterFunc.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.0.4', '<scope>compile</scope>');
           }
@@ -236,10 +241,10 @@ module.exports = yeoman.generators.Base.extend({
               "            <column name=\"last_modified_by\" type=\"varchar(50)\"/>\n" +
               "            <column name=\"last_modified_date\" type=\"timestamp\"/>";
               jhipsterFunc.addColumnToLiquibaseEntityChangeset(file, columns);
-            } else {
-              //javers annotations must be added here to repositories
             }
-
+          } else {
+            // add javers annotations to repository
+            jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
           }
         }, this);
       }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -76,7 +76,7 @@ module.exports = yeoman.generators.Base.extend({
         message: 'Choose which audit framework you would like to use.',
         choices: [
           {name: 'Custom JHipster auditing (works with SQL)', value: 'custom'},
-          {name: 'Javers auditing framework (works with MongoDB)', value: 'javers'}
+          {name: '[BETA] Javers auditing framework (works with MongoDB)', value: 'javers'}
         ],
         default: 'custom'
       },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -255,9 +255,17 @@ module.exports = yeoman.generators.Base.extend({
               jhipsterFunc.addColumnToLiquibaseEntityChangeset(file, columns);
             }
           } else {
-            // add javers annotations to repository
-            jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
-            jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
+
+            // check if repositories are already annotated
+            var auditTableAnnotation = '@JaversSpringDataAuditable';
+            var pattern = new RegExp(auditTableAnnotation, 'g')
+            var content = fs.readFileSync(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
+            
+            if (!pattern.test(content)) {
+              // add javers annotations to repository
+              jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
+              jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
+            }
           }
         }, this);
       }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -133,6 +133,14 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   writing: {
+    updateYeomanConfig : function() {
+      var enityGeneratorConfig = {
+        auditFramework: this.auditFramework
+      }
+
+      this.config.set('auditFramework', this.auditFramework);
+    },
+
     setupGlobalVar : function () {
       this.baseName = jhipsterVar.baseName;
       this.packageName = jhipsterVar.packageName;
@@ -246,6 +254,7 @@ module.exports = yeoman.generators.Base.extend({
           } else {
             // add javers annotations to repository
             jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
+            jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
           }
         }, this);
       }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -195,7 +195,9 @@ module.exports = yeoman.generators.Base.extend({
       } else {
 
         var files = [
-          { from: this.javaTemplateDir + '/config/audit/_JaversAuthorProvider.java', to: this.javaDir + 'config/audit/JaversAuthorProvider.java'}
+          { from: this.javaTemplateDir + '/config/audit/_JaversAuthorProvider.java', to: this.javaDir + 'config/audit/JaversAuthorProvider.java'},
+          { from: this.javaTemplateDir + '/config/audit/_EntityAuditAction.java', to: this.javaDir + 'config/audit/EntityAuditAction.java'},
+          { from: this.javaTemplateDir + '/web/rest/_JaversAEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'}
         ];
 
         this.copyFiles(files);

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -256,7 +256,7 @@ module.exports = yeoman.generators.Base.extend({
             // check if repositories are already annotated
             var auditTableAnnotation = '@JaversSpringDataAuditable';
             var pattern = new RegExp(auditTableAnnotation, 'g')
-            var content = fs.readFileSync(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
+            var content = this.fs.read(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
 
             if (!pattern.test(content)) {
               // add javers annotations to repository

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -201,14 +201,14 @@ module.exports = yeoman.generators.Base.extend({
         if (this.buildTool === 'maven') {
 
           if (this.databaseType === 'mongodb') {
-             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.4', '<scope>compile</scope>');
+             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.5', '<scope>compile</scope>');
              jhipsterFunc.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.0.4', '<scope>compile</scope>');
           }
 
         } else if (this.buildTool === 'gradle') {
 
           if (this.databaseType === 'mongodb') {
-            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.4');
+            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.5');
             jhipsterFunc.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.0.4');
           }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -115,7 +115,7 @@ module.exports = yeoman.generators.Base.extend({
       this.prompt(prompts, function (props) {
 
         // Check if an invalid database, auditFramework is selected
-        if (props.auditFramework === 'default' && jhipsterVar.databaseType === 'mongodb') {
+        if (props.auditFramework === 'custom' && jhipsterVar.databaseType === 'mongodb') {
           this.env.error(chalk.red.bold('ERROR!') + ' The JHipster audit framework supports SQL databases only...\n');
         } else if (props.auditFramework === 'javers' && jhipsterVar.databaseType === 'sql') {
           this.env.error(chalk.red.bold('ERROR!') + ' The Javers audit framework supports MongoDB databases only...\n');
@@ -134,10 +134,6 @@ module.exports = yeoman.generators.Base.extend({
 
   writing: {
     updateYeomanConfig : function() {
-      var enityGeneratorConfig = {
-        auditFramework: this.auditFramework
-      }
-
       this.config.set('auditFramework', this.auditFramework);
     },
 
@@ -268,7 +264,6 @@ module.exports = yeoman.generators.Base.extend({
               jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
             }
           }
-          this.log(this.auditedEntities);
         }, this);
       }
     },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -206,14 +206,14 @@ module.exports = yeoman.generators.Base.extend({
         if (this.buildTool === 'maven') {
 
           if (this.databaseType === 'mongodb') {
-             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.1', '<scope>compile</scope>');
+             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.4', '<scope>compile</scope>');
              jhipsterFunc.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.0.4', '<scope>compile</scope>');
           }
 
         } else if (this.buildTool === 'gradle') {
 
           if (this.databaseType === 'mongodb') {
-            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.1');
+            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.4');
             jhipsterFunc.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.0.4');
           }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -163,7 +163,7 @@ module.exports = yeoman.generators.Base.extend({
 
     writeBaseFiles : function () {
 
-      if (this.auditFramework === 'default') {
+      if (this.auditFramework === 'custom') {
         // collect files to copy
         var files = [
           { from: this.javaTemplateDir + '/config/audit/_AsyncEntityAuditEventWriter.java', to: this.javaDir + 'config/audit/AsyncEntityAuditEventWriter.java'},

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -197,8 +197,7 @@ module.exports = yeoman.generators.Base.extend({
         var files = [
           { from: this.javaTemplateDir + '/config/audit/_JaversAuthorProvider.java', to: this.javaDir + 'config/audit/JaversAuthorProvider.java'},
           { from: this.javaTemplateDir + '/config/audit/_EntityAuditAction.java', to: this.javaDir + 'config/audit/EntityAuditAction.java'},
-          { from: this.javaTemplateDir + '/domain/_EntityAuditEvent.java', to: this.javaDir + 'domain/EntityAuditEvent.java'},
-          { from: this.javaTemplateDir + '/web/rest/_JaversEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'}
+          { from: this.javaTemplateDir + '/domain/_EntityAuditEvent.java', to: this.javaDir + 'domain/EntityAuditEvent.java'}
         ];
 
         this.copyFiles(files);
@@ -260,7 +259,7 @@ module.exports = yeoman.generators.Base.extend({
             var auditTableAnnotation = '@JaversSpringDataAuditable';
             var pattern = new RegExp(auditTableAnnotation, 'g')
             var content = fs.readFileSync(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
-            
+
             if (!pattern.test(content)) {
               // add javers annotations to repository
               jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
@@ -274,16 +273,29 @@ module.exports = yeoman.generators.Base.extend({
     writeAuditPageFiles : function () {
       // Create audit log page for entities
       if (this.auditPage) {
-        var files = [
-          { from: this.javaTemplateDir + '/web/rest/_EntityAuditResource.java', to: this.javaDir + 'web/rest/EntityAuditResource.java'},
-          { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudits.html', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudits.html'},
-          { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.detail.html', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.detail.html'},
-          { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.js'},
-          { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.controller.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.controller.js'},
-          { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.detail.controller.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.detail.controller.js'},
-          { from: this.webappDir + '/scripts/components/admin/_entityAudit.service.js', to: this.webappDir + 'scripts/components/admin/entityAudit.service.js'}
-        ];
-        this.copyFiles(files);
+        if (this.auditFramework === 'custom') {
+          var files = [
+            { from: this.javaTemplateDir + '/web/rest/_EntityAuditResource.java', to: this.javaDir + 'web/rest/EntityAuditResource.java'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudits.html', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudits.html'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.detail.html', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.detail.html'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.js'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.controller.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.controller.js'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.detail.controller.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.detail.controller.js'},
+            { from: this.webappDir + '/scripts/components/admin/_entityAudit.service.js', to: this.webappDir + 'scripts/components/admin/entityAudit.service.js'}
+          ];
+          this.copyFiles(files);
+        } else {
+          var files = [
+            { from: this.javaTemplateDir + '/web/rest/_JaversEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudits.html', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudits.html'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.detail.html', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.detail.html'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.js'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.controller.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.controller.js'},
+            { from: this.webappDir + '/scripts/app/admin/entityAudit/_entityAudit.detail.controller.js', to: this.webappDir + 'scripts/app/admin/entityAudit/entityAudit.detail.controller.js'},
+            { from: this.webappDir + '/scripts/components/admin/_entityAudit.service.js', to: this.webappDir + 'scripts/components/admin/entityAudit.service.js'}
+          ];
+          this.copyFiles(files);
+        }
         // add the scripts to index.html
         jhipsterFunc.addJavaScriptToIndex('components/admin/entityAudit.service.js');
         jhipsterFunc.addJavaScriptToIndex('app/admin/entityAudit/entityAudit.js');
@@ -295,6 +307,7 @@ module.exports = yeoman.generators.Base.extend({
         // add new menu entry
         jhipsterFunc.addElementToAdminMenu('entityAudit', 'list-alt', jhipsterVar.enableTranslation);
         jhipsterFunc.addTranslationKeyToAllLanguages('entityAudit', 'Entity Audit', 'addAdminElementTranslationKey', jhipsterVar.enableTranslation);
+
       }
 
     },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -33,6 +33,9 @@ module.exports = yeoman.generators.Base.extend({
       if (args == 'default') {
         this.defaultAudit = true;
       }
+      if (args === 'javers') {
+        this.javersAudit = true;
+      }
     },
 
     displayLogo: function () {
@@ -108,6 +111,11 @@ module.exports = yeoman.generators.Base.extend({
 
     if (this.defaultAudit) {
       this.auditFramework = 'custom'
+      this.updateType = 'all';
+      this.auditPage = true;
+      done();
+    } else if(this.javersAudit) {
+      this.auditFramework = 'javers'
       this.updateType = 'all';
       this.auditPage = true;
       done();
@@ -201,14 +209,14 @@ module.exports = yeoman.generators.Base.extend({
         if (this.buildTool === 'maven') {
 
           if (this.databaseType === 'mongodb') {
-             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.5', '<scope>compile</scope>');
+             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.7', '<scope>compile</scope>');
              jhipsterFunc.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.0.4', '<scope>compile</scope>');
           }
 
         } else if (this.buildTool === 'gradle') {
 
           if (this.databaseType === 'mongodb') {
-            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.5');
+            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.7');
             jhipsterFunc.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.0.4');
           }
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -197,7 +197,8 @@ module.exports = yeoman.generators.Base.extend({
         var files = [
           { from: this.javaTemplateDir + '/config/audit/_JaversAuthorProvider.java', to: this.javaDir + 'config/audit/JaversAuthorProvider.java'},
           { from: this.javaTemplateDir + '/config/audit/_EntityAuditAction.java', to: this.javaDir + 'config/audit/EntityAuditAction.java'},
-          { from: this.javaTemplateDir + '/web/rest/_JaversAEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'}
+          { from: this.javaTemplateDir + '/domain/_EntityAuditEvent.java', to: this.javaDir + 'domain/EntityAuditEvent.java'},
+          { from: this.javaTemplateDir + '/web/rest/_JaversEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'}
         ];
 
         this.copyFiles(files);

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -139,6 +139,7 @@ module.exports = yeoman.generators.Base.extend({
       this.angularAppName = jhipsterVar.angularAppName;
       this.frontendBuilder = jhipsterVar.frontendBuilder;
       this.buildTool = jhipsterVar.buildTool;
+      this.databaseType = jhipsterVar.databaseType;
       this.changelogDate = jhipsterFunc.dateFormatForLiquibase();
       this.webappDir = jhipsterVar.webappDir;
       this.javaTemplateDir = 'src/main/java/package';

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -229,8 +229,10 @@ module.exports = yeoman.generators.Base.extend({
         this.log('\n' + chalk.bold.green('I\'m Updating selected entities ') + chalk.bold.yellow(this.entitiesToUpdate));
         this.log('\n' + chalk.bold.yellow('Make sure these classes does not extend any other class to avoid any errors during compilation.'));
         var jsonObj = null;
-        this.entitiesToUpdate.forEach(function(entityName) {
+        this.auditedEntities = [];
 
+        this.entitiesToUpdate.forEach(function(entityName) {
+          this.auditedEntities.push("\"" + entityName + "\"")
           if (this.auditFramework === 'custom') {
             // extend entity with AbstractAuditingEntity
             jhipsterFunc.replaceContent(this.javaDir + 'domain/' + entityName + '.java', 'public class ' + entityName, 'public class ' + entityName + ' extends AbstractAuditingEntity');
@@ -266,6 +268,7 @@ module.exports = yeoman.generators.Base.extend({
               jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
             }
           }
+          this.log(this.auditedEntities);
         }, this);
       }
     },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -138,6 +138,7 @@ module.exports = yeoman.generators.Base.extend({
       this.packageName = jhipsterVar.packageName;
       this.angularAppName = jhipsterVar.angularAppName;
       this.frontendBuilder = jhipsterVar.frontendBuilder;
+      this.buildTool = jhipsterVar.buildTool;
       this.changelogDate = jhipsterFunc.dateFormatForLiquibase();
       this.webappDir = jhipsterVar.webappDir;
       this.javaTemplateDir = 'src/main/java/package';
@@ -181,10 +182,26 @@ module.exports = yeoman.generators.Base.extend({
           'import ' + this.packageName + '.config.audit.EntityAuditEventListener;');
         // remove the jsonIgnore on the audit fields so that the values can be passed
         jhipsterFunc.replaceContent(this.javaDir + 'domain/AbstractAuditingEntity.java', '\s*@JsonIgnore', '', true);
+
       } else {
 
-      }
+        //add required third party dependencies
+        if (this.buildTool === 'maven') {
 
+          if (this.databaseType === 'sql') {
+             jhipsterFunc.addMavenDependency('org.javers', 'javers-spring-boot-starter-mongo', '1.4.1', '<scope>compile</scope>');
+             jhipsterFunc.addMavenDependency('org.mongodb', 'mongo-java-driver', '3.0.4', '<scope>compile</scope>');
+          }
+
+        } else if (this.buildTool === 'gradle') {
+
+          if (this.databaseType === 'mongodb') {
+            jhipsterFunc.addGradleDependency('compile', 'org.javers', 'javers-spring-boot-starter-mongo', '1.4.1');
+            jhipsterFunc.addGradleDependency('compile', 'org.mongodb', 'mongo-java-driver', '3.0.4');
+          }
+
+        }
+      }
     },
 
     updateEntityFiles : function () {

--- a/generators/app/templates/src/main/java/package/config/audit/_JaversAuthorProvider.java
+++ b/generators/app/templates/src/main/java/package/config/audit/_JaversAuthorProvider.java
@@ -1,0 +1,14 @@
+package <%=packageName%>.config.audit;
+
+import org.javers.spring.auditable.AuthorProvider;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JaversAuthorProvider implements AuthorProvider {
+
+   @Override
+   public String provide() {
+       String userName = SecurityUtils.getCurrentUserLogin();
+       return (userName != null ? userName : Constants.SYSTEM_ACCOUNT);
+   }
+}

--- a/generators/app/templates/src/main/java/package/config/audit/_JaversAuthorProvider.java
+++ b/generators/app/templates/src/main/java/package/config/audit/_JaversAuthorProvider.java
@@ -1,5 +1,7 @@
 package <%=packageName%>.config.audit;
 
+import <%=packageName%>.config.Constants;
+import <%=packageName%>.security.SecurityUtils;
 import org.javers.spring.auditable.AuthorProvider;
 import org.springframework.stereotype.Component;
 

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -7,7 +7,7 @@ import java.time.ZonedDateTime;
 <% if (databaseType == 'sql' && auditFramework === 'custom') { %>
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;<% } else if (databaseType === 'mongodb' && auditFramework === 'javers')%>
+import javax.validation.constraints.Size;<% } else if (databaseType === 'mongodb' && auditFramework === 'javers') {%>
 import org.javers.core.commit.CommitMetadata;
 import org.javers.core.diff.Change;<% }%>
 import java.io.Serializable;
@@ -20,7 +20,7 @@ import java.util.Objects;
 public class EntityAuditEvent implements Serializable{
 
     private static final long serialVersionUID = 1L;
-    <if (databaseType === 'sql' && auditFramework === 'custom') { %>
+    <% if (databaseType == 'sql' && auditFramework === 'custom') { %>
   	@Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -53,21 +53,21 @@ public class EntityAuditEvent implements Serializable{
     @Column(name = "modified_date", nullable = false)
     private ZonedDateTime modifiedDate;
     <% } else if (databaseType === 'mongodb' && auditFramework === 'javaers') { %>
-      private Long id;
+    private Long id;
 
-      private Long entityId;
+    private Long entityId;
 
-      private String entityType;
+    private String entityType;
 
-      private String action;
+    private String action;
 
-      private String entityValue;
+    private String entityValue;
 
-      private Integer commitVersion;
+    private Integer commitVersion;
 
-      private String modifiedBy;
+    private String modifiedBy;
 
-      private ZonedDateTime modifiedDate;
+    private ZonedDateTime modifiedDate;
     <% } %>
 
     public Long getId() {
@@ -165,7 +165,7 @@ public class EntityAuditEvent implements Serializable{
             '}';
     }
 
-    <% if (databaseType === 'mongodb' && auditFramework === 'javaers') { %>
+    <% if (databaseType === 'mongodb' && auditFramework === 'javers') { %>
     public static entityAuditEvent fromJaversChange(Change change) {
       EntityAuditEvent entityAuditEvent = new EntityAuditEvent();
 

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -196,6 +196,7 @@ public class EntityAuditEvent implements Serializable{
                 break;
         }
 
+        entityAuditEvent.setId(snapshot.getCommitId().toString());
         entityAuditEvent.setCommitVersion(Math.round(snapshot.getVersion()));
         entityAuditEvent.setEntityType(snapshot.getManagedType().getName());
         entityAuditEvent.setEntityId(snapshot.getGlobalId().value().split("/")[1]);
@@ -217,6 +218,18 @@ public class EntityAuditEvent implements Serializable{
             entityAuditEvent.setEntityValue(sb.toString());
         }
 
+        LocalDateTime localTime = snapshot.getCommitMetadata().getCommitDate();
+
+        ZonedDateTime modifyDate = ZonedDateTime.of(localTime.getYear(),
+          localTime.getMonthOfYear(),
+          localTime.getDayOfMonth(),
+          localTime.getHourOfDay(),
+          localTime.getMinuteOfHour(),
+          localTime.getSecondOfMinute(),
+          localTime.getMillisOfSecond(),
+          ZoneId.systemDefault());
+
+        entityAuditEvent.setModifiedDate(modifyDate);
 
         return entityAuditEvent;
 

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -205,22 +205,22 @@ public class EntityAuditEvent implements Serializable{
         entityAuditEvent.setEntityId(snapshot.getGlobalId().value().split("/")[1]);
         entityAuditEvent.setModifiedBy(snapshot.getCommitMetadata().getAuthor());
 
-        if (snapshot.getChanged().size() > 0) {
+        if (snapshot.getState().getProperties().size() > 0) {
             int count = 0;
             StringBuilder sb = new StringBuilder("{");
 
-            for (String s:snapshot.getChanged()) {
+            for (String s:snapshot.getState().getProperties()) {
                 count++;
                 Object propertyValue = snapshot.getPropertyValue(s);
                 sb.append("\"" + s + "\": \"" + propertyValue + "\"");
-                if (count < snapshot.getChanged().size()) {
-                    sb.append(",");
+                if (count < snapshot.getState().getProperties().size()) {
+                  sb.append(",");
                 }
-            }
-            sb.append("}");
-            entityAuditEvent.setEntityValue(sb.toString());
-        }
+             }
 
+             sb.append("}");
+             entityAuditEvent.setEntityValue(sb.toString());
+        }
         LocalDateTime localTime = snapshot.getCommitMetadata().getCommitDate();
 
         ZonedDateTime modifyDate = ZonedDateTime.of(localTime.getYear(),

--- a/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
+++ b/generators/app/templates/src/main/java/package/domain/_EntityAuditEvent.java
@@ -8,7 +8,10 @@ import java.time.ZonedDateTime;
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;<% } else if (databaseType === 'mongodb' && auditFramework === 'javers') {%>
-import org.javers.core.metamodel.object.CdoSnapshot;<% }%>
+import org.javers.core.metamodel.object.CdoSnapshot;
+import org.joda.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;<% }%>
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -181,7 +184,7 @@ public class EntityAuditEvent implements Serializable{
     }
 
     <% if (databaseType === 'mongodb' && auditFramework === 'javers') { %>
-    public static entityAuditEvent fromJaversSnapshot(CdoSnapshot snapshot) {
+    public static EntityAuditEvent fromJaversSnapshot(CdoSnapshot snapshot) {
         EntityAuditEvent entityAuditEvent = new EntityAuditEvent();
 
         switch (snapshot.getType()) {

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -54,7 +54,7 @@ public class JaversEntityAuditResource {
     @Secured(AuthoritiesConstants.ADMIN)
     public List<String> getAuditedEntities() {
 
-      return Arrays.asList();
+      return Arrays.asList(<%- auditedEntities %>);
     }
 
     /**

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -108,14 +108,14 @@ public class JaversEntityAuditResource {
     @Secured(AuthoritiesConstants.ADMIN)
     public ResponseEntity<EntityAuditEvent> getPrevVersion(@RequestParam(value = "qualifiedName") String qualifiedName,
                                                            @RequestParam(value = "entityId") String entityId,
-                                                           @RequestParam(value = "commitVersion") Integer commitVersion)
+                                                           @RequestParam(value = "commitVersion") Long commitVersion)
         throws URISyntaxException, ClassNotFoundException {
 
         Class entityTypeToFetch = Class.forName("<%=packageName%>.domain." + qualifiedName);
 
         QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityTypeToFetch)
                                            .limit(1)
-                                           .withCommitId(new BigDecimal(commitVersion))
+                                           .withVersion(commitVersion - 1)
                                            .withNewObjectChanges(true);
 
         EntityAuditEvent prev = EntityAuditEvent.fromJaversSnapshot(javers.findSnapshots(jqlQuery.build()).get(0));

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -82,11 +82,11 @@ public class JaversEntityAuditResource {
 
         List<EntityAuditEvent> auditEvents = new ArrayList<>();
 
-       snapshots.forEach(snapshot -> {
+        snapshots.forEach(snapshot -> {
            EntityAuditEvent event = EntityAuditEvent.fromJaversSnapshot(snapshot);
            event.setEntityType(entityType);
            auditEvents.add(event);
-       });
+        });
 
         Page<EntityAuditEvent> page = new PageImpl<>(auditEvents);
 

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -113,7 +113,7 @@ public class JaversEntityAuditResource {
 
         Class entityTypeToFetch = Class.forName("<%=packageName%>.domain." + qualifiedName);
 
-        QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityTypeToFetch)
+        QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityId, entityTypeToFetch)
                                            .limit(1)
                                            .withVersion(commitVersion - 1)
                                            .withNewObjectChanges(true);

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -54,9 +54,7 @@ public class JaversEntityAuditResource {
     @Secured(AuthoritiesConstants.ADMIN)
     public List<String> getAuditedEntities() {
 
-      return Arrays.asList(
-          // jhipster-entity-audit-needle-add-audited-entity
-      );
+      return Arrays.asList();
     }
 
     /**

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -1,7 +1,6 @@
 package <%=packageName%>.web.rest;
 
 import <%=packageName%>.domain.EntityAuditEvent;
-import <%=packageName%>.repository.EntityAuditEventRepository;
 import <%=packageName%>.web.rest.util.PaginationUtil;
 import org.javers.core.Javers;
 import org.javers.core.metamodel.object.CdoSnapshot;
@@ -79,7 +78,7 @@ public class JaversEntityAuditResource {
         Class entityTypeToFetch = Class.forName("%=packageName%>.domain" + entityType);
         QueryBuilder jqlQuery = QueryBuilder.byClass(entityTypeToFetch)
                                             .limit(limit)
-                                            .withNewObjectChanges(true).;
+                                            .withNewObjectChanges(true);
 
         List<CdoSnapshot> snapshots =  javers.findSnapshots(jqlQuery.build());
 

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -73,7 +73,7 @@ public class JaversEntityAuditResource {
         log.debug("REST request to get a page of EntityAuditEvents");
         Pageable pageRequest = createPageRequest(limit);
 
-        Class entityTypeToFetch = Class.forName("%=packageName%>.domain" + entityType);
+        Class entityTypeToFetch = Class.forName("<%=packageName%>.domain." + entityType);
         QueryBuilder jqlQuery = QueryBuilder.byClass(entityTypeToFetch)
                                             .limit(limit)
                                             .withNewObjectChanges(true);
@@ -111,10 +111,11 @@ public class JaversEntityAuditResource {
                                                            @RequestParam(value = "commitVersion") Integer commitVersion)
         throws URISyntaxException, ClassNotFoundException {
 
-        Class entityTypeToFetch = Class.forName("%=packageName%>.domain" + qualifiedName);
+        Class entityTypeToFetch = Class.forName("<%=packageName%>.domain." + qualifiedName);
 
-        QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityId, entityTypeToFetch)
+        QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityTypeToFetch)
                                            .limit(1)
+                                           .withCommitId(new BigDecimal(commitVersion))
                                            .withNewObjectChanges(true);
 
         EntityAuditEvent prev = EntityAuditEvent.fromJaversSnapshot(javers.findSnapshots(jqlQuery.build()).get(0));

--- a/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
+++ b/generators/app/templates/src/main/java/package/web/rest/_JaversEntityAuditResource.java
@@ -1,0 +1,131 @@
+package <%=packageName%>.web.rest;
+
+import <%=packageName%>.domain.EntityAuditEvent;
+import <%=packageName%>.repository.EntityAuditEventRepository;
+import <%=packageName%>.web.rest.util.PaginationUtil;
+import <%=packageName%>.security.AuthoritiesConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.annotation.Secured;
+import com.codahale.metrics.annotation.Timed;
+
+import javax.inject.Inject;
+import java.net.URISyntaxException;
+import java.util.List;
+
+/**
+ * REST controller for getting the audit events for entity
+ */
+@RestController
+@RequestMapping("/api")
+public class JaversEntityAuditResource {
+
+    private final Logger log = LoggerFactory.getLogger(JaversEntityAuditResource.class);
+
+    @Inject
+    private Javers javers;
+
+
+    /**
+     * fetches all the audited entity types
+     *
+     * @return
+     */
+    @RequestMapping(value = "/audits/entity/all",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    @Secured(AuthoritiesConstants.ADMIN)
+    public List<String> getAuditedEntities() {
+
+      //TODO this must come from configuration maybe or something else
+      QueryBuilder jqlQuery = QueryBuilder.byClass(Book.class)
+                                          .withNewObjectChanges(true).;
+
+      List<Change> changes = javers.findChanges(jqlQuery.build());
+
+      return javers.getJsonConverter().toJson(changes);
+      //return entityAuditEventRepository.findAllEntityTypes();
+    }
+
+    /**
+     * fetches the last 100 change list for an entity class, if limit is passed fetches that many changes
+     *
+     * @return
+     */
+    @RequestMapping(value = "/audits/entity/changes",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    @Secured(AuthoritiesConstants.ADMIN)
+    public ResponseEntity<List<EntityAuditEvent>> getChanges(@RequestParam(value = "entityType") String entityType,
+                                                             @RequestParam(value = "limit") int limit)
+        throws URISyntaxException {
+        log.debug("REST request to get a page of EntityAuditEvents");
+        Pageable pageRequest = createPageRequest(limit);
+
+        //Get the class by name!!
+        QueryBuilder jqlQuery = QueryBuilder.byClass(Book.class)
+                                            .limit(limit)
+                                            .withNewObjectChanges(true).;
+
+        List<Change> changes = javers.findChanges(jqlQuery.build());
+
+        // Convert each javers event to EntityAuditEvent required by jhipster web gui
+        HttpHeaders header = PaginationUtil.generatePaginationHttpHeaders(page, "/api/audits/entity/changes");
+
+        return javers.getJsonConverter().toJson(changes);
+
+        //Page<EntityAuditEvent> page = entityAuditEventRepository.findAllByEntityType(entityType, pageRequest);
+        //HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/audits/entity/changes");
+        //return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
+
+    }
+
+    /**
+     * fetches a previous version for for an entity class and id
+     *
+     * @return
+     */
+    @RequestMapping(value = "/audits/entity/changes/version/previous",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    @Secured(AuthoritiesConstants.ADMIN)
+    public ResponseEntity<EntityAuditEvent> getPrevVersion(@RequestParam(value = "qualifiedName") String qualifiedName,
+                                                           @RequestParam(value = "entityId") Long entityId,
+                                                           @RequestParam(value = "commitVersion") Integer commitVersion)
+        throws URISyntaxException {
+
+          // Get class by name!
+          // Is it possible to filter on commit id or do I need to fetch all?
+          QueryBuilder jqlQuery = QueryBuilder.byInstanceId(entityId, Book.class)
+                                              .limit(1)
+                                              .withNewObjectChanges(true);
+
+        EntityAuditEvent prev = entityAuditEventRepository.findOneByEntityTypeAndEntityIdAndCommitVersion(qualifiedName, entityId, commitVersion);
+        return new ResponseEntity<>(prev, HttpStatus.OK);
+
+    }
+
+    /**
+     * creates a page request object for PaginationUti
+     *
+     * @return
+     */
+    private Pageable createPageRequest(int size) {
+        return new PageRequest(0, size);
+    }
+
+}

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -65,6 +65,8 @@ module.exports = yeoman.generators.Base.extend({
 
       if (ypeof this.entityConfig.data.auditFramework !== 'undefined') {
         this.auditFramework = this.entityConfig.data.auditFramework;
+      } else {
+        this.auditFramework = 'custom';
       }
       return;
     }
@@ -89,6 +91,7 @@ module.exports = yeoman.generators.Base.extend({
       this.props = props;
       // To access props later use this.props.someOption;
       this.enableAudit = props.enableAudit;
+      this.auditFramework = this.config.get('auditFramework');
       done();
     }.bind(this));
   },
@@ -117,24 +120,33 @@ module.exports = yeoman.generators.Base.extend({
         this.log('\n' + chalk.bold.green('I\'m updating the entity for audit ') + chalk.bold.yellow(this.entityConfig.entityClass));
 
         var entityName = this.entityConfig.entityClass;
-        // extend entity with AbstractAuditingEntity
-        jhipsterFunc.replaceContent(javaDir + 'domain/' + entityName + '.java', 'public class ' + entityName, 'public class ' + entityName + ' extends AbstractAuditingEntity');
-        // extend DTO with AbstractAuditingDTO
-        if(this.entityConfig.data.dto == 'mapstruct') {
-          jhipsterFunc.replaceContent(javaDir + 'web/rest/dto/' + entityName + 'DTO.java', 'public class ' + entityName + 'DTO', 'public class ' + entityName + 'DTO extends AbstractAuditingDTO');
+
+        if (this.auditFramework === 'custom') {
+          // extend entity with AbstractAuditingEntity
+          jhipsterFunc.replaceContent(javaDir + 'domain/' + entityName + '.java', 'public class ' + entityName, 'public class ' + entityName + ' extends AbstractAuditingEntity');
+          // extend DTO with AbstractAuditingDTO
+          if(this.entityConfig.data.dto == 'mapstruct') {
+            jhipsterFunc.replaceContent(javaDir + 'web/rest/dto/' + entityName + 'DTO.java', 'public class ' + entityName + 'DTO', 'public class ' + entityName + 'DTO extends AbstractAuditingDTO');
+          }
+
+          //update liquibase changeset
+          var file = glob.sync("src/main/resources/config/liquibase/changelog/*" + entityName + ".xml")[0];
+          var columns = "<column name=\"created_by\" type=\"varchar(50)\">\n" +
+          "                <constraints nullable=\"false\"/>\n" +
+          "            </column>\n" +
+          "            <column name=\"created_date\" type=\"timestamp\" defaultValueDate=\"${now}\">\n" +
+          "                <constraints nullable=\"false\"/>\n" +
+          "            </column>\n" +
+          "            <column name=\"last_modified_by\" type=\"varchar(50)\"/>\n" +
+          "            <column name=\"last_modified_date\" type=\"timestamp\"/>";
+          jhipsterFunc.addColumnToLiquibaseEntityChangeset(file, columns);
+
+        } else if (this.auditFramework === 'javers') {
+          // add javers annotations to repository
+          jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
+          jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
         }
 
-        //update liquibase changeset
-        var file = glob.sync("src/main/resources/config/liquibase/changelog/*" + entityName + ".xml")[0];
-        var columns = "<column name=\"created_by\" type=\"varchar(50)\">\n" +
-        "                <constraints nullable=\"false\"/>\n" +
-        "            </column>\n" +
-        "            <column name=\"created_date\" type=\"timestamp\" defaultValueDate=\"${now}\">\n" +
-        "                <constraints nullable=\"false\"/>\n" +
-        "            </column>\n" +
-        "            <column name=\"last_modified_by\" type=\"varchar(50)\"/>\n" +
-        "            <column name=\"last_modified_date\" type=\"timestamp\"/>";
-        jhipsterFunc.addColumnToLiquibaseEntityChangeset(file, columns);
 
       }
     },

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -144,10 +144,6 @@ module.exports = yeoman.generators.Base.extend({
               jhipsterFunc.replaceContent(javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
               jhipsterFunc.replaceContent(javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
             }
-          } else {
-            // add javers annotations to repository
-            jhipsterFunc.replaceContent(javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
-            jhipsterFunc.replaceContent(javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
           }
 
 

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -64,6 +64,11 @@ module.exports = yeoman.generators.Base.extend({
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
       return;
     }
+
+    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.auditFramework !== 'undefined') {
+      this.auditFramework = this.entityConfig.data.auditFramework;
+    }
+
     var done = this.async();
     var prompts = [
       {
@@ -132,6 +137,7 @@ module.exports = yeoman.generators.Base.extend({
         return;
       }
       jhipsterFunc.updateEntityConfig(this.entityConfig.filename, 'enableEntityAudit', this.enableAudit);
+      jhipsterFunc.updateEntityConfig(this.entityConfig.filename, 'auditFramework', this.auditFramework);
     }
   },
 

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -63,7 +63,7 @@ module.exports = yeoman.generators.Base.extend({
     if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.enableEntityAudit !== 'undefined') {
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
 
-      if (ypeof this.entityConfig.data.auditFramework !== 'undefined') {
+      if (typeof this.entityConfig.data.auditFramework !== 'undefined') {
         this.auditFramework = this.entityConfig.data.auditFramework;
       } else {
         this.auditFramework = 'custom';

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -34,7 +34,7 @@ module.exports = yeoman.generators.Base.extend({
     },
 
     checkDBType: function () {
-      if (jhipsterVar.databaseType != 'sql') {
+      if (jhipsterVar.databaseType != 'sql' && jhipsterVar.databaseType != 'mongodb') {
         // exit if DB type is not SQL
         this.abort = true;
       }

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -62,11 +62,17 @@ module.exports = yeoman.generators.Base.extend({
     // don't prompt if data are imported from a file
     if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.enableEntityAudit !== 'undefined') {
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
+
+      if (ypeof this.entityConfig.data.auditFramework !== 'undefined') {
+        this.auditFramework = this.entityConfig.data.auditFramework;
+      }
       return;
     }
 
     if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.auditFramework !== 'undefined') {
+      this.enableAudit = true;
       this.auditFramework = this.entityConfig.data.auditFramework;
+      return
     }
 
     var done = this.async();

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -142,12 +142,19 @@ module.exports = yeoman.generators.Base.extend({
           jhipsterFunc.addColumnToLiquibaseEntityChangeset(file, columns);
 
         } else if (this.auditFramework === 'javers') {
-          // add javers annotations to repository
-          jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
-          jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
+
+          // check if repositories are already annotated
+          var auditTableAnnotation = '@JaversSpringDataAuditable';
+          var pattern = new RegExp(auditTableAnnotation, 'g')
+          var content = fs.readFileSync(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
+
+          if (!pattern.test(content)) {
+            // add javers annotations to repository
+            jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
+            jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
+          }
+
         }
-
-
       }
     },
     updateConfig : function() {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -63,18 +63,12 @@ module.exports = yeoman.generators.Base.extend({
     if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.enableEntityAudit !== 'undefined') {
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
 
-      if (ypeof this.entityConfig.data.auditFramework !== 'undefined') {
-        this.auditFramework = this.entityConfig.data.auditFramework;
+      if (typeof this.config.get('auditFramework'); !== 'undefined') {
+        this.auditFramework = this.config.get('auditFramework');
       } else {
         this.auditFramework = 'custom';
       }
       return;
-    }
-
-    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.auditFramework !== 'undefined') {
-      this.enableAudit = true;
-      this.auditFramework = this.entityConfig.data.auditFramework;
-      return
     }
 
     var done = this.async();

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -60,10 +60,21 @@ module.exports = yeoman.generators.Base.extend({
       return;
     }
     // don't prompt if data are imported from a file
-    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data) {
+    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.enableEntityAudit !== 'undefined') {
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
-      this.auditFramework = this.config.get('auditFramework')
+
+      if (ypeof this.entityConfig.data.auditFramework !== 'undefined') {
+        this.auditFramework = this.entityConfig.data.auditFramework;
+      } else {
+        this.auditFramework = 'custom';
+      }
       return;
+    }
+
+    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.auditFramework !== 'undefined') {
+      this.enableAudit = true;
+      this.auditFramework = this.entityConfig.data.auditFramework;
+      return
     }
 
     var done = this.async();
@@ -131,53 +142,12 @@ module.exports = yeoman.generators.Base.extend({
           jhipsterFunc.addColumnToLiquibaseEntityChangeset(file, columns);
 
         } else if (this.auditFramework === 'javers') {
-
-
-          // check if repositories are already annotated
-          if (this.fs.exists(javaDir + 'repository/' + entityName + 'Repository.java')) {
-            var auditTableAnnotation = '@JaversSpringDataAuditable';
-            var pattern = new RegExp(auditTableAnnotation, 'g')
-            var content = this.fs.read.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
-
-            if (!pattern.test(content)) {
-              // add javers annotations to repository
-              jhipsterFunc.replaceContent(javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
-              jhipsterFunc.replaceContent(javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
-            }
-          }
-
-
-          // check if the rest resource for ui is existing and add the new audited entity
-          if (this.fs.exists(javaDir + 'web/rest/JaversEntityAuditResource.java')) {
-            this.auditedEntities = [];
-
-            var existingEntities = [];
-            try {
-              existingEntities = fs.readdirSync('.jhipster');
-            } catch (e) {
-              this.log(chalk.red.bold('ERROR!') + ' Could not read entities, you might not have generated any entities yet.\n');
-            }
-
-            existingEntities.forEach(function(entry) {
-              if (entry.indexOf('.json') !== -1) {
-                var entityConfig = this.fs.readJSON('.jhipster/' + entry);
-                var entityName = entry.replace('.json','');
-                var enableEntityAudit = entityConfig.data.enableEntityAudit;
-
-                if (entityConfig.enableEntityAudit) {
-                  this.auditedEntities.push("\"" + entityName + "\"")
-                }
-              }
-            });
-
-            this.auditedEntities.push("\"" + entityName + "\"")
-
-            var files = [
-              { from: this.javaTemplateDir + '/web/rest/_JaversEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'}
-            ];
-            this.copyFiles(files);
-          }
+          // add javers annotations to repository
+          jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
+          jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
         }
+
+
       }
     },
     updateConfig : function() {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -47,6 +47,24 @@ module.exports = yeoman.generators.Base.extend({
       this.log(chalk.white('Running ' + chalk.bold('JHipster Entity Audit') + ' Generator! ' + chalk.yellow('v' + packagejs.version + '\n')));
     },
 
+    getEntitityNames: function () {
+      var existingEntities = [],
+      existingEntityNames = [];
+      try{
+        existingEntityNames = fs.readdirSync('.jhipster');
+      } catch(e) {
+        this.log(chalk.red.bold('ERROR!') + ' Could not read entities, you might not have generated any entities yet. I will continue to install audit files, entities will not be updated...\n');
+      }
+
+      existingEntityNames.forEach(function(entry) {
+        if(entry.indexOf('.json') !== -1){
+          var entityName = entry.replace('.json','');
+          existingEntities.push(entityName);
+        }
+      });
+      this.existingEntities = existingEntities;
+    },
+
     validate: function () {
       // this shouldnt be run directly
       if (!this.entityConfig) {
@@ -59,11 +77,12 @@ module.exports = yeoman.generators.Base.extend({
     if (this.abort){
       return;
     }
+
     // don't prompt if data are imported from a file
     if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.enableEntityAudit !== 'undefined') {
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
 
-      if (typeof this.config.get('auditFramework'); !== 'undefined') {
+      if (typeof this.config.get('auditFramework') !== 'undefined') {
         this.auditFramework = this.config.get('auditFramework');
       } else {
         this.auditFramework = 'custom';
@@ -139,9 +158,22 @@ module.exports = yeoman.generators.Base.extend({
           // add javers annotations to repository
           jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'public interface ' + entityName + 'Repository', '@JaversSpringDataAuditable\npublic interface ' + entityName + 'Repository');
           jhipsterFunc.replaceContent(this.javaDir + 'repository/' + entityName + 'Repository.java', 'domain.' + entityName + ';', 'domain.' + entityName + ';\nimport org.javers.spring.annotation.JaversSpringDataAuditable;');
+
+          //update the list of audited entities if audit page is available
+          if (this.fs.exists(this.javaDir + 'web/rest/EntityAuditResource.java')) {
+            this.existingEntities.push(entityName);
+            this.auditedEntities = [];
+
+            this.existingEntities.forEach(function(entityName) {
+                this.auditedEntities.push("\"" + entityName + "\"")
+            }
+
+            var files = [
+              { from: this.javaTemplateDir + '/web/rest/_JaversEntityAuditResource.java', to: this.javaDir + 'web/rest/JaversEntityAuditResource.java'}
+            ];
+            this.copyFiles(files);
+          }
         }
-
-
       }
     },
     updateConfig : function() {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -35,7 +35,7 @@ module.exports = yeoman.generators.Base.extend({
 
     checkDBType: function () {
       if (jhipsterVar.databaseType != 'sql' && jhipsterVar.databaseType != 'mongodb') {
-        // exit if DB type is not SQL
+        // exit if DB type is not SQL or MongoDB
         this.abort = true;
       }
     },

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -60,21 +60,10 @@ module.exports = yeoman.generators.Base.extend({
       return;
     }
     // don't prompt if data are imported from a file
-    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.enableEntityAudit !== 'undefined') {
+    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data) {
       this.enableAudit = this.entityConfig.data.enableEntityAudit;
-
-      if (typeof this.entityConfig.data.auditFramework !== 'undefined') {
-        this.auditFramework = this.entityConfig.data.auditFramework;
-      } else {
-        this.auditFramework = 'custom';
-      }
+      this.auditFramework = this.config.get('auditFramework')
       return;
-    }
-
-    if (this.entityConfig.useConfigurationFile == true &&  this.entityConfig.data && typeof this.entityConfig.data.auditFramework !== 'undefined') {
-      this.enableAudit = true;
-      this.auditFramework = this.entityConfig.data.auditFramework;
-      return
     }
 
     var done = this.async();
@@ -146,7 +135,7 @@ module.exports = yeoman.generators.Base.extend({
           // check if repositories are already annotated
           var auditTableAnnotation = '@JaversSpringDataAuditable';
           var pattern = new RegExp(auditTableAnnotation, 'g')
-          var content = fs.readFileSync(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
+          var content = this.fs.read(this.javaDir + 'repository/' + entityName + 'Repository.java', 'utf8');
 
           if (!pattern.test(content)) {
             // add javers annotations to repository
@@ -162,7 +151,6 @@ module.exports = yeoman.generators.Base.extend({
         return;
       }
       jhipsterFunc.updateEntityConfig(this.entityConfig.filename, 'enableEntityAudit', this.enableAudit);
-      jhipsterFunc.updateEntityConfig(this.entityConfig.filename, 'auditFramework', this.auditFramework);
     }
   },
 


### PR DESCRIPTION
Not yet complete, following is missing:

* ~~listing all audited entities~~
* get previous snapshot (but it is on the way: https://github.com/javers/javers/pull/318)
* the option is marked as [BETA]

update #4 

Edit: @deepu105 ~~Do you know how to prevent yeoman from replacing " with the corresponding html entity (&#34;) inside a .java file?~~ It is ``<%-``